### PR TITLE
Use Kint 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I love Kint, but it's a little hard to get it to work perfectly within Laravel. 
 
 Install with composer
 
-    composer require rtconner/laravel-kint "~2.0"
+    composer require rtconner/laravel-kint "~3.0"
 
 Then add this to `config/app.php`
 
@@ -34,11 +34,7 @@ Use Kint as you would normally.
 ```php
 d($var); // debug dump
 
-ddd($var); // debug dump and die
-
 s($var); // simple print
-
-sd($var); // simple print and die
 ```
 
 There is an also an added feature to allow you to easily dump variables from within **blade templates**.
@@ -46,10 +42,6 @@ Notice no semi-colon at the end, and must be on their own line of code.
 
 ```
 @d($var)
-
-@ddd($var)
-
-@sd($var)
 
 @s($var)
 ```
@@ -63,24 +55,6 @@ To enable configuration first create the `config/kint.php` file in your app.
 [See config/kint.php](config/kint.php) for configuration options.
 
 See [Kint documentation](https://github.com/kint-php/kint) for details on configuration options.
-
-
-### How Do I Override Laravel's dd() method?
-
-There is no clean way. You will have to edit the `public/index.php` file in your app. Place the following code directly after
-`require __DIR__.'/../bootstrap/autoload.php';`
-
-```php
-/**
- * Override Laravel's built-in dd() method to call Kint::dump()
- */
-function dd()
-{
-    $_ = func_get_args();
-    call_user_func_array( array( 'Kint', 'dump' ), $_ );
-    die;
-}
-```
 
 #### Credits
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": ">=5.3",
-		"kint-php/kint": "~1.0"
+		"kint-php/kint": "^2.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/config/kint.php
+++ b/config/kint.php
@@ -14,35 +14,35 @@ return [
 	/*
 	 * If set to false, Kint will become silent
 	 */ 
-	'enabled' => true, // I suggest replacing true with env('APP_DEBUG'), 
+	'enabled_mode' => true, // I suggest replacing true with env('APP_DEBUG'), 
 
-	'displayCalledFrom' => true,
+	'display_called_from' => true,
 	
-	'fileLinkFormat' => ini_get('xdebug.file_link_format'),
+	'file_link_format' => ini_get('xdebug.file_link_format'),
 
 	/*
 	 * The file paths displayed within debug traces
 	*/
-	'appRootDirs' => array(
+	'app_root_dirs' => array(
 		base_path()=>'.', // just display a period at application root
 // 		base_path()=>base_path(), // display the full path
 	),
 
-	'maxStrLength' => 80,
+	'strlen_max' => 80,
 	
-	'maxLevels' => 5,
+	'max_depth' => 5,
 
-	'theme' => 'original',
+	'theme' => 'original.css',
 		
-	'expandedByDefault'=>false,
+	'expanded'=>false,
 		
-	'cliDetection'=>true,
+	'cli_detection'=>true,
 
-	'cliColors'=>true,
+	'cli_colors'=>true,
 
 	/*
 	 * Allows you to use these in blade templates:
-	 * @d($var) @ddd($var) @sd($var) @s($var) @dd($var)
+	 * @d($var) @s($var)
 	 */
 	'blade_directives' => true,
 	

--- a/src/KintServiceProvider.php
+++ b/src/KintServiceProvider.php
@@ -44,8 +44,10 @@ class KintServiceProvider extends ServiceProvider {
 		}
 		
 		foreach($configs as $key => $val) {
-			if($key == 'enabled') {
-				Kint::enabled($val);
+			if($key == 'strlen_max') {
+				Kint_Renderer_Rich::$strlen_max = $val;
+			} elseif($key == 'theme') {
+				Kint_Renderer_Rich::$theme = $val;
 			} elseif(property_exists('Kint', $key)) {
 				Kint::$$key = $val;
 			}
@@ -58,17 +60,8 @@ class KintServiceProvider extends ServiceProvider {
 			Blade::directive('d', function($variable) {
 				return "<?php echo d($variable); ?>";
 			});
- 			Blade::directive('dd', function($variable) {
- 				return "<?php echo dd($variable); ?>";
- 			});
- 			Blade::directive('ddd', function($variable) {
- 				return "<?php echo ddd($variable); ?>";
- 			});
  			Blade::directive('s', function($variable) {
  				return "<?php echo s($variable); ?>";
- 			});
- 			Blade::directive('sd', function($variable) {
- 				return "<?php echo sd($variable); ?>";
  			});
 		}
 	}


### PR DESCRIPTION
Kint 2.0 has been released! It's much simpler to implement, but as you'll see from the PR it's also a fairly large breaking change, so you'll want to major version bump.

Alternatively, you could reimplement the `dd`, `ddd`, `sd` helpers and translate your config names to the new var names to maintain backwards compatibility