### PR TITLE
add package discovery for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,12 @@
 			"Conner\\Kint\\": "src/"
 		}
 	},
+	"extra": {
+		"laravel": {
+		    "providers": [
+			"Conner\\Kint\\KintServiceProvider"
+		    ]
+		}
+	},
 	"minimum-stability": "dev"
 }


### PR DESCRIPTION
little addition to let Laravel 5.5 detect installed packages and autoload providers and aliases
https://laravel.com/docs/master/packages#package-discovery